### PR TITLE
Fix codyco-superbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,10 +40,6 @@ install(FILES
  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
  DESTINATION ${CMAKE_CONFIG_DEST})
 
-install(FILES
- "${PROJECT_SOURCE_DIR}/test/cmake/FindEigen.cmake"
-DESTINATION "share/cmake/Eigen")
-
 # add a target to generate API documentation with Doxygen
 if(GENERATE_DOCUMENTATION)
     find_package(Doxygen REQUIRED)


### PR DESCRIPTION
See https://travis-ci.org/robotology/codyco-superbuild/builds/157687988 
`FindEigen.cmake` was removed in https://github.com/ocra-recipes/eigen_lgsm/commit/1bf9b51ab1a487d6e396e12bc3287eb5e8fd42f7 .
